### PR TITLE
merge w/ msharov master

### DIFF
--- a/configure
+++ b/configure
@@ -429,7 +429,7 @@ fi
 
 SubHeadLibsProgs() {
 local INCPATH LIBPATH LIBSUFFIX found pname pcall esciv
-INCPATH="$ac_var_oldincludedir $ac_var_includedir $ac_var_gccincludedir $ac_var_customincdir /usr/include /usr/include/x86_64-linux-gnu"
+INCPATH="$ac_var_oldincludedir $ac_var_includedir $ac_var_gccincludedir $ac_var_customincdir /usr/include"
 INCPATH=`echo $INCPATH | sed 's/\\\\//g'`
 for i in $HEADERS; do
     for p in $INCPATH; do
@@ -440,7 +440,7 @@ for i in $HEADERS; do
     done
 done
 
-LIBPATH="`echo $LD_LIBRARY_PATH | tr ':' ' '` $ac_var_libdir $ac_var_gcclibdir $ac_var_customlibdir /usr/lib /usr/local/lib /lib /usr/lib/x86_64-linux-gnu"
+LIBPATH="`echo $LD_LIBRARY_PATH | tr ':' ' '` $ac_var_libdir $ac_var_gcclibdir $ac_var_customlibdir /lib /usr/lib /usr/local/lib"
 LIBPATH=`echo $LIBPATH | sed 's/\\\\//g'`
 LIBSUFFIX="so a la dylib"
 for i in $LIBS; do


### PR DESCRIPTION
…nu to configure"

This reverts commit a5973fbfe252e0b222105b2bab8b51691c4b4c4a.

Revisiting this ever occuring problem to remove the fix that does
not work. Simply adding the nonstandard path to allow configure to
find the libraries by default is not sufficient because libustl will
then be installed in /usr/lib, where it will not be found by anybody
looking for libraries in the system specified library location. The only
correct fix is to manually specify --libdir=/usr/lib/x86_64-linux-gnu
--includedir=/usr/include/x86_64-linux-gnu when running configure. This
way dependency libraries are found and uSTL library and headers are
installed where the system expects them to be. There is no way to do this
automatically because the /usr/lib/platform scheme can not be detected
by the configure script - there is no way to know what the system decided
the platform name is or that it is being used this way.
